### PR TITLE
Feat/command utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",
     "start": "node dist/bot.js",
     "watch": "nodemon src/bot.ts"

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,6 +1,3 @@
-import dotenv from "dotenv";
-dotenv.config();
-
 import { CommandoClient } from "discord.js-commando";
 import { env, config, getConfig } from "./config";
 import path from "path";

--- a/src/commands/fun/gif.ts
+++ b/src/commands/fun/gif.ts
@@ -20,9 +20,9 @@ export default class GifCommand extends Command {
       args: [
         {
           key: "search",
-          prompt: "Where should I look for a gif?",
+          prompt: "where should I look for a gif?",
           type: "string",
-          error: "That doesn't seem to be a place.",
+          error: "that doesn't seem to be a place.",
           default: "",
         },
       ],

--- a/src/commands/utils/debug.ts
+++ b/src/commands/utils/debug.ts
@@ -1,0 +1,46 @@
+import { Command, CommandoMessage } from "discord.js-commando";
+import { config, getConfig } from "../../config";
+
+export default class TestCommand extends Command {
+  constructor(client: any) {
+    super(client, {
+      name: "botctl",
+      group: "utils",
+      memberName: "botctl",
+      description: "cOnTrOl ThE bOt",
+      aliases: ["ctl", "debug"],
+      guildOnly: true,
+      ownerOnly: true,
+      args: [
+        {
+          key: "action",
+          prompt: "what admin tool should be used?",
+          type: "string",
+          error: "that doesn't appear to be a valid tool.",
+          oneOf: ["config", "reload"],
+        },
+      ],
+    });
+  }
+  async run(msg: CommandoMessage, { action }: { action: "reload" | "config" }) {
+    switch (action) {
+      case "reload":
+        getConfig()
+          .catch((e) => {
+            return msg.say(
+              `There was a problem reloading the bot's config: \`${e}\``
+            );
+          })
+          .then(() => {
+            return msg.say("Config reloaded!");
+          });
+        break;
+      case "config":
+        return msg.say(`\`\`\`json\n${JSON.stringify(config, null, 2)}\`\`\``);
+      default:
+        return msg.say("tHe CoDe MoNkEyS bRoKe It");
+    }
+
+    return null;
+  }
+}

--- a/src/commands/utils/jpeg.ts
+++ b/src/commands/utils/jpeg.ts
@@ -17,9 +17,9 @@ export default class JpegCommand extends Command {
       args: [
         {
           key: "target",
-          prompt: "Which image should I JPEGify?",
+          prompt: "which image should I JPEGify?",
           type: "string",
-          error: "Say what?",
+          error: "say what?",
           default: "",
         },
       ],

--- a/src/commands/utils/no.ts
+++ b/src/commands/utils/no.ts
@@ -13,7 +13,7 @@ export default class NoCommand extends Command {
     });
   }
 
-  async run(msg: CommandoMessage, { action }: { action: string }) {
+  async run(msg: CommandoMessage) {
     // If cache is empty, get messages
     if (msg.channel.messages.cache.size == 0) {
       await msg.channel.messages.fetch();

--- a/src/commands/utils/no.ts
+++ b/src/commands/utils/no.ts
@@ -1,0 +1,43 @@
+import { Command, CommandoClient, CommandoMessage } from "discord.js-commando";
+import { config } from "../../config";
+
+export default class NoCommand extends Command {
+  constructor(client: CommandoClient) {
+    super(client, {
+      name: "no",
+      group: "util",
+      memberName: "no",
+      aliases: ["bad", "nope"],
+      description: "Remove the most recent bot message in this channel",
+      guildOnly: true,
+    });
+  }
+
+  async run(msg: CommandoMessage, { action }: { action: string }) {
+    // If cache is empty, get messages
+    if (msg.channel.messages.cache.size == 0) {
+      await msg.channel.messages.fetch();
+    }
+
+    // Get the most recent bot message
+    let botMessage = msg.channel.messages.cache
+      .filter((m) => m.author === this.client.user)
+      .last();
+
+    // Pull the last user command trigger
+    let author = msg.channel.messages.cache
+      .filter((m) => m.content.startsWith(this.client.commandPrefix))
+      .last()?.author;
+
+    // Check who's calling the command (either the origional caller, or an owner)
+    if (config.owners.includes(msg.author.id) || msg.author == author) {
+      botMessage?.edit("_**Removed**_").catch(() => {
+        return msg.say("Unable to remove the message");
+      });
+      msg.delete();
+    } else {
+      return msg.say("You don't have permission to do that.");
+    }
+    return null;
+  }
+}

--- a/src/commands/utils/role.ts
+++ b/src/commands/utils/role.ts
@@ -17,7 +17,7 @@ export default class RoleCommand extends Command {
           prompt: "(g)ive or (t)ake a role?",
           type: "string",
           oneOf: ["g", "give", "gib", "t", "take"],
-          error: "Hmm... I couldn't understand that :(",
+          error: "hmm... I couldn't understand that :(",
           default: "",
         },
         {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,14 +1,17 @@
 import { Environment, Configuration } from "./types";
+import { ConfigNotFoundError } from "./models";
 import { isURL } from "./util";
+import dotenv from "dotenv";
 import path from "path";
 import got from "got";
 import fs from "fs";
-import { ConfigNotFoundError } from "./models";
 
 export let env: Environment;
 export let config: Configuration;
 
 export async function getConfig() {
+  dotenv.config();
+
   env = {
     botToken: process.env.BOT_TOKEN!,
     tenorToken: process.env.TENOR_TOKEN!,


### PR DESCRIPTION
- Add `!no` command to remove/hide the previous bot command. I think this could be improved in the future by possibly enabling the use of spoiler tags and whatnot.
- Add debugging commands for viewing and reloading the config (owner only)
- Modified config code to support reloading
- Tweaked command descriptions