### PR TITLE
Add error handling

### DIFF
--- a/packages/bot/data/config.json
+++ b/packages/bot/data/config.json
@@ -1,6 +1,6 @@
 {
   "owners": ["217448431545745408", "140599441328439297"],
-  "listeners": ["uselessConversions", "iFunnyFixer"],
+  "errorChannel": "893296394478182450",
   "commands": {
     "jpeg": {
       "options": {

--- a/packages/bot/src/listeners/commands/commandError.ts
+++ b/packages/bot/src/listeners/commands/commandError.ts
@@ -4,8 +4,8 @@ import { send } from "@sapphire/plugin-editable-commands";
 import { MessageEmbed } from "discord.js";
 
 export class UserEvent extends Listener<typeof Events.CommandError> {
-  public async run(e: Error, payload: CommandErrorPayload) {
-    await payload.message.guild?.channels
+  public async run(e: Error, { message }: CommandErrorPayload) {
+    await message.guild?.channels
       .fetch("893296394478182450")
       .then((channel) => {
         if (channel?.isText()) {
@@ -14,8 +14,25 @@ export class UserEvent extends Listener<typeof Events.CommandError> {
           });
           embed.setColor("RED");
 
-          embed.addField("Message", e.message);
-          embed.addField("Error Type", e.name);
+          embed.addField("Error Message", e.message, true);
+          embed.addField("Error Type", e.name, true);
+
+          if (message.member) {
+            const pfp = message.member.user.avatarURL();
+
+            if (pfp) {
+              embed.setThumbnail(pfp);
+            }
+
+            embed.addField("Message Author", message.member?.user.username);
+          }
+
+          if (message.content) {
+            embed.addField("Message Content", message.content);
+          }
+
+          embed.setTimestamp(new Date());
+          embed.setURL(message.url);
 
           if (e.stack) {
             embed.addField("Stack", `\`${e.stack}\``);
@@ -27,6 +44,6 @@ export class UserEvent extends Listener<typeof Events.CommandError> {
         }
       });
 
-    await send(payload.message, "Sorry, something went wrong :(");
+    await send(message, "Sorry, something went wrong :(");
   }
 }

--- a/packages/bot/src/listeners/commands/commandError.ts
+++ b/packages/bot/src/listeners/commands/commandError.ts
@@ -1,6 +1,7 @@
 import type { CommandErrorPayload, Events } from "@sapphire/framework";
 import { Listener } from "@sapphire/framework";
 import { send } from "@sapphire/plugin-editable-commands";
+import { MessageEmbed } from "discord.js";
 
 export class UserEvent extends Listener<typeof Events.CommandError> {
   public async run(e: Error, payload: CommandErrorPayload) {
@@ -8,7 +9,21 @@ export class UserEvent extends Listener<typeof Events.CommandError> {
       .fetch("893296394478182450")
       .then((channel) => {
         if (channel?.isText()) {
-          channel.send(e.message);
+          const embed = new MessageEmbed({
+            title: "Error Details",
+          });
+          embed.setColor("RED");
+
+          embed.addField("Message", e.message);
+          embed.addField("Error Type", e.name);
+
+          if (e.stack) {
+            embed.addField("Stack", `\`${e.stack}\``);
+          }
+
+          channel.send({
+            embeds: [embed],
+          });
         }
       });
 

--- a/packages/bot/src/listeners/commands/commandError.ts
+++ b/packages/bot/src/listeners/commands/commandError.ts
@@ -1,0 +1,17 @@
+import type { CommandErrorPayload, Events } from "@sapphire/framework";
+import { Listener } from "@sapphire/framework";
+import { send } from "@sapphire/plugin-editable-commands";
+
+export class UserEvent extends Listener<typeof Events.CommandError> {
+  public async run(e: Error, payload: CommandErrorPayload) {
+    await payload.message.guild?.channels
+      .fetch("893296394478182450")
+      .then((channel) => {
+        if (channel?.isText()) {
+          channel.send(e.message);
+        }
+      });
+
+    await send(payload.message, "Sorry, something went wrong :(");
+  }
+}


### PR DESCRIPTION
When a command errors, log an error message to the logging channel specified in the config with details regarding the command that caused the error.